### PR TITLE
ci(e2e): add GitHub Actions workflow to run build + preview + Cypress

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,6 @@ jobs:
     name: Build and run Cypress E2E (preview on 3200)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,52 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - chore/**
+      - feat/**
+      - test/**
+      - ci/**
+
+jobs:
+  e2e:
+    name: Build and run Cypress E2E (preview on 3200)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Cypress run against preview
+        uses: cypress-io/github-action@v6
+        with:
+          start: npm run preview
+          wait-on: 'http://localhost:3200'
+          browser: chrome
+
+      - name: Upload Cypress artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-artifacts
+          if-no-files-found: ignore
+          path: |
+            cypress/screenshots
+            cypress/videos
+            cypress/logs
+

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,13 +2,7 @@ name: e2e
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      - chore/**
-      - feat/**
-      - test/**
-      - ci/**
+ 
 
 jobs:
   e2e:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3200',
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+    specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+    supportFile: 'cypress/support/e2e.ts',
+    viewportWidth: 1280,
+    viewportHeight: 720,
+    video: false,
+    screenshotOnRunFailure: true,
+    defaultCommandTimeout: 10000,
+    requestTimeout: 10000,
+    responseTimeout: 10000,
+  },
+})
+


### PR DESCRIPTION
Adds a GitHub Actions workflow to run build + vite preview on port 3200 and Cypress E2E using cypress-io/github-action. Uploads artifacts on failure.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CI workflow to run Cypress end-to-end tests on PRs and pushes (main and feature branches), building the app, launching a preview, and running tests in Chrome with a 30-minute timeout.
  * Added Cypress end-to-end configuration (base URL, viewport, spec pattern, timeouts, screenshots on failure).
  * Automatically uploads screenshots, videos, and logs as artifacts on failures.

* **Chores**
  * Standardized Node.js setup with caching to speed installs and ensure consistent Linux test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->